### PR TITLE
Appel de la fonction 'add_event'.

### DIFF
--- a/src/cog_planning/info/credits.txt
+++ b/src/cog_planning/info/credits.txt
@@ -3,3 +3,4 @@ Tonitch#2192 <d.tonitch@gmail.com>
 scribble#8876 
 Lyss <delpratflo@cy-tech.fr>
 Maestro#8364 <yoyou20@hotmail.fr>
+Sac2Poubelle

--- a/src/cog_planning/settings.py
+++ b/src/cog_planning/settings.py
@@ -2,6 +2,6 @@ command_prefix = "$"
 creation_form_url = 'http://planning.unionrolistes.fr'
 calendar_url = 'http://planning.unionrolistes.fr/Calendar'
 site_url = 'http://site.unionrolistes.fr'
-announcement_channel = 'planning-jdr'
+announcement_channel = 'planning-jdr'   # TODO laisser le choix du channel à l'utilisateur
 msg_delete_delay = 6
 tmp_wh_location = '/usr/local/src/URbot'

--- a/src/cog_planning/strings.py
+++ b/src/cog_planning/strings.py
@@ -1,4 +1,4 @@
-from urpy import lcl
+from Bot_Base.src.urpy.localization import lcl
 
 on_join = lcl("🎉 Congratulations ! {user} has joined the game !")
 on_leave = lcl("😭 Despair and loneliness... {user} has left us. {user} is a meanie.")


### PR DESCRIPTION
Concernant l'appel de la fonction **add_event**, elle requiert plusieurs paramètres et il doit se faire au script trouvable au chemin **Bot_Planning_python/src/cog_planning/cog.py**. Les trois paramètres requièrent une compréhension plutôt approfondie du fonctionnement du code. De manière simple et concise, voici ce que j'en ai ressorti : 

 - un objet Calendar, qui doit être instancié à partir du fichier XML du calendrier web. D'après un ancien développeur du projet (voir le channel Discord), le fichier correspondant se trouve à ce chemin : **src/www/Calendar/data/events.xml**. 
*Ici, nous indiquons au code, auquel fichier il doit ajouter l'évènement*.
 
 - un objet FieldStorage. Quand un utilisateur valide son formulaire, une requête HTTP exécute le script trouvable à ce chemin : **Web_Planning/src/www/cgi/create_post.py**. En important ce dernier dans notre fichier de base, nous importons aussi la classe **FieldStorage**, qui prend automatiquement les informations du formulaire pour les organiser dans notre import au calendrier. C'est pourquoi un objet de la classe **FieldStorage** est instancié à chaque activation du script. 
 *Sur ce paramètre, nous indiquons au code, quelles sont les informations appartenant à l'évènement*.
P.s : à chaque instanciation, c'est un nouvel objet qui est crée. Puisque la variable est locale, elle disparaît après son utilisation finale, qui est l'appel de la fonction **add_event**.

 - un objet discord.embed, soit le message envoyé au salon Discord '#planning-jdr'. 

Pour plus de détails, consultez directement l'origine des classes Calendar (lien [ici](https://github.com/UnionRolistes/Bot_Base/blob/c7524fc63490d2f2b8d6647725d7dd9042624def/src/urpy/xml.py#L62)),  **cgi.FieldStorage** et **discord.embed**.