### PR TITLE
fix: correct casing of urbot import (URbot -> urbot)

### DIFF
--- a/src/cog_planning/cog.py
+++ b/src/cog_planning/cog.py
@@ -21,7 +21,7 @@ from Bot_Base.src.urpy.get_ressources import get_planning_anncmnt_mdl
 from Bot_Base.src.urpy.my_commands import *
 from Bot_Base.src.urpy.utils import error_log, get_informations, log
 from Bot_Base.src.urpy.xml import Calendar
-from Bot_Base.src.bot.URbot import main, URBot
+from Bot_Base.src.bot.urbot import main, URBot
 from cgi import FieldStorage    # nécessaire pour xml.Calendar.add_event
 
 import info


### PR DESCRIPTION
Closes #58

Corrige la casse de l'import dans `src/cog_planning/cog.py` : `Bot_Base.src.bot.URbot` → `Bot_Base.src.bot.urbot` (le fichier réel est en minuscules).

Fait partie de la dockerisation d'URbot (Bot_Base + Bot_Planning_python + Bot_Presentation), où ce bug provoque un crash fatal au démarrage sous Linux.