### PR TITLE
fix: crash sur $version/$credit et $done/$cancel sans session

### DIFF
--- a/src/cog_planning/cog.py
+++ b/src/cog_planning/cog.py
@@ -12,6 +12,7 @@ import pickle
 import sys
 import logging
 import re
+from importlib import resources
 from pathlib import Path
 import os
 
@@ -288,7 +289,8 @@ class Planning(MyCog):
         msg = ctx.message
         author = ctx.author
 
-        del self.edit_mode_users[author]
+        if author in self.edit_mode_users:
+            del self.edit_mode_users[author]
 
     @commands.Cog.listener()
     async def on_ready(self):


### PR DESCRIPTION
Closes #62

Deux crashes constatés en production juste après le déploiement Docker :
- Import manquant de `resources` (importlib) → NameError sur `$version`/`$credit`
- `on_cancel_or_done` sans garde de présence → KeyError sur `$done`/`$cancel` hors session

Voir #62 pour le détail complet.