### PR TITLE
feat: rejoint traefik-public, labels de routage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,11 +10,21 @@ services:
       dockerfile: Dockerfile
     container_name: web-planning
     restart: unless-stopped
+    # Port encore publié pendant la préparation de la bascule Traefik :
+    # Apache en dépend tant que la bascule finale n'a pas eu lieu. Retiré
+    # une fois Apache arrêté (Traefik devient l'unique point d'entrée).
     ports:
       - "8082:80"
     networks:
       - default
       - bot_base_default
+      - traefik-public
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.web-planning.rule=Host(`planning.unionrolistes.fr`)"
+      - "traefik.http.routers.web-planning.entrypoints=websecure"
+      - "traefik.http.routers.web-planning.tls.certresolver=le"
+      - "traefik.http.services.web-planning.loadbalancer.server.port=80"
     volumes:
       # Même événements que planning-api (Bot_Base/api-data/events.xml,
       # chemin hôte absolu car web-planning et planning-api sont deux
@@ -30,4 +40,6 @@ services:
 
 networks:
   bot_base_default:
+    external: true
+  traefik-public:
     external: true


### PR DESCRIPTION
Prépare la bascule Traefik (remplace Apache comme ingress unique pour les domaines *.unionrolistes.fr). Découverte par labels Docker plutôt qu'un vhost Apache séparé à maintenir.

Le port publié (8082) reste en place tant qu'Apache en a besoin — retiré dans une PR de suivi une fois la bascule finale (Apache arrêté) confirmée. Réseau bot_base_default conservé pour l'appel à planning-api.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>