### PR TITLE
ci: bloque les trailers de co-auteur IA sur les commits

### DIFF
--- a/.github/workflows/no-ai-coauthor.yml
+++ b/.github/workflows/no-ai-coauthor.yml
@@ -1,0 +1,36 @@
+name: No AI co-author
+
+on:
+  pull_request:
+  push:
+    branches: [main, master]
+
+jobs:
+  check-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Refuse AI co-author trailers (PR commits)
+        if: github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+          bad=0
+          for sha in $(git log --format='%H' "origin/${{ github.event.pull_request.base.ref }}..HEAD"); do
+            if git log -1 --format='%B' "$sha" | grep -iqE '^co-authored-by:.*(claude|anthropic|copilot|chatgpt|openai|gemini|codex)'; then
+              echo "::error::Commit $sha has an AI co-author trailer — not allowed in this repo."
+              bad=1
+            fi
+          done
+          exit $bad
+
+      - name: Refuse AI co-author trailers (direct push)
+        if: github.event_name == 'push'
+        run: |
+          set -euo pipefail
+          if git log -1 --format='%B' HEAD | grep -iqE '^co-authored-by:.*(claude|anthropic|copilot|chatgpt|openai|gemini|codex)'; then
+            echo "::error::HEAD commit has an AI co-author trailer — not allowed in this repo."
+            exit 1
+          fi

--- a/.github/workflows/no-ai-coauthor.yml
+++ b/.github/workflows/no-ai-coauthor.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main, master]
 
+permissions:
+  contents: read
+
 jobs:
   check-commits:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Vérifie chaque commit d'une PR (et le HEAD d'un push direct sur main/master) pour un trailer Co-authored-by mentionnant un outil IA (Claude, Copilot, ChatGPT...) et échoue le check si trouvé.