### PR TITLE
perf: retirer docker-php-ext-install curl (redondant, 547MB -> 509MB)

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -7,10 +7,13 @@
 # CGI Apache.
 FROM php:8.4-apache
 
+# curl est déjà compilé statiquement dans php:8.4-apache (php -m | grep curl
+# le montre sans rien installer) — docker-php-ext-install curl ne servait
+# qu'à recompiler une extension déjà présente. apache2-utils reste
+# nécessaire : htpasswd est appelé par docker-entrypoint.sh au démarrage
+# pour générer .htpasswd depuis un secret Komodo.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libcurl4-openssl-dev \
     apache2-utils \
-    && docker-php-ext-install curl \
     && a2enmod rewrite \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Résumé
- \`curl\` est déjà compilé statiquement dans l'image de base \`php:8.4-apache\` (\`php -m | grep curl\` le confirme sans rien installer).
- \`apt-get install libcurl4-openssl-dev && docker-php-ext-install curl\` recompilait une extension déjà présente, pour rien.
- \`apache2-utils\` reste installé : \`htpasswd\` est appelé par \`docker-entrypoint.sh\` au démarrage pour générer \`.htpasswd\` (accès \`/Calendar/ADMIN/\`) depuis un secret Komodo.

## Mesures
Taille de l'image : 547MB -> 509MB (-38MB)

## Test plan
- [x] Build réussi sur le VPS
- [x] \`curl_init()\` fonctionne toujours dans l'image finale
- [x] \`htpasswd\` présent, \`a2query -m rewrite\` confirme le module actif