### PR TITLE
perf: php-fpm + nginx sur Alpine (547MB -> 93MB)

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -5,35 +5,28 @@
 # planning-api. PHP pur : pas d'interpréteur supplémentaire à sandboxer, pas
 # de mod_cgi, surface d'attaque nettement réduite par rapport à l'ancien
 # CGI Apache.
-FROM php:8.4-apache
+#
+# php-fpm + nginx sur Alpine plutôt que php:8.4-apache (Debian) : aucune
+# RewriteRule/RewriteCond dans le repo, la seule fonctionnalité Apache
+# utilisée est le Basic Auth de Calendar/ADMIN/ (.htaccess), qui a un
+# équivalent nginx direct (auth_basic, même format .htpasswd). curl est
+# déjà compilé statiquement dans php:8.4-fpm-alpine, comme dans la variante
+# -apache. apache2-utils reste installé (nom du paquet identique sur
+# Alpine) : htpasswd est toujours appelé par docker-entrypoint.sh.
+FROM php:8.4-fpm-alpine
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libcurl4-openssl-dev \
-    apache2-utils \
-    && docker-php-ext-install curl \
-    && a2enmod rewrite \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache nginx apache2-utils
+
+COPY nginx.conf /etc/nginx/nginx.conf
 
 COPY www/ /var/www/html/
 
-# Pas de listing de répertoire (Options -Indexes), et /Calendar/data/ n'est
-# jamais servi en HTTP : PHP le lit directement sur disque
-# (simplexml_load_file), pas de requête HTTP nécessaire. Le volume monté à
-# cet endroit contient aussi webhooks.json (URLs de webhook Discord,
-# sensibles — partagé avec planning-api), donc explicitement bloqué plutôt
-# que de compter sur l'absence de lien vers ce fichier.
-RUN { \
-    echo '<Directory "/var/www/html">'; \
-    echo '    Options -Indexes +FollowSymLinks'; \
-    echo '    AllowOverride All'; \
-    echo '    Require all granted'; \
-    echo '</Directory>'; \
-    echo '<Directory "/var/www/html/Calendar/data">'; \
-    echo '    Require all denied'; \
-    echo '</Directory>'; \
-    } > /etc/apache2/conf-enabled/planning.conf
-
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+EXPOSE 80
+
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["apache2-foreground"]
+
+# php-fpm en arriere-plan (-D), nginx au premier plan comme PID 1.
+CMD ["sh", "-c", "php-fpm -D && exec nginx -g 'daemon off;'"]

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -1,0 +1,60 @@
+worker_processes 1;
+error_log /dev/stderr warn;
+pid /tmp/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+    access_log /dev/stdout;
+    sendfile on;
+
+    server {
+        listen 80;
+        root /var/www/html;
+        index index.php index.html;
+
+        # /Calendar/data/ n'est jamais servi en HTTP : PHP le lit directement
+        # sur disque (simplexml_load_file). Le volume monté a cet endroit
+        # contient aussi webhooks.json (sensible), donc explicitement bloque.
+        location /Calendar/data/ {
+            deny all;
+            return 403;
+        }
+
+        # Zone admin protegee par mot de passe (.htpasswd genere au demarrage
+        # par docker-entrypoint.sh). "^~" + location imbriquee : sans ca, le
+        # bloc generique "~ \.php$" plus bas passerait AVANT ce bloc pour les
+        # fichiers .php de l'admin (les locations regex sont prioritaires sur
+        # les locations prefixe simples chez nginx) et l'auth serait
+        # contournee pour les .php - verifie explicitement au build (401 sans
+        # identifiants, 200 avec).
+        location ^~ /Calendar/ADMIN/ {
+            auth_basic "Vous etes sur une page d'administration protegee";
+            auth_basic_user_file /var/www/html/Calendar/ADMIN/.htpasswd;
+
+            location ~ \.php$ {
+                auth_basic "Vous etes sur une page d'administration protegee";
+                auth_basic_user_file /var/www/html/Calendar/ADMIN/.htpasswd;
+                fastcgi_pass 127.0.0.1:9000;
+                fastcgi_index index.php;
+                include fastcgi_params;
+                fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            }
+        }
+
+        location ~ \.php$ {
+            fastcgi_pass 127.0.0.1:9000;
+            fastcgi_index index.php;
+            include fastcgi_params;
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        }
+
+        location / {
+            try_files $uri $uri/ =404;
+        }
+    }
+}


### PR DESCRIPTION
## Résumé
Aucune `RewriteRule`/`RewriteCond` dans le repo. La seule fonctionnalité Apache utilisée est le Basic Auth de `Calendar/ADMIN/` (`.htaccess`) — équivalent nginx direct (`auth_basic`), même format `.htpasswd`. `apache2-utils` reste installé (nom de paquet identique sur Alpine) pour `htpasswd`, toujours appelé par `docker-entrypoint.sh`.

## Point d'attention traité avec soin
Chez nginx, un bloc `location ~ \.php$` générique est **prioritaire** sur un `location /Calendar/ADMIN/` simple pour les requêtes `.php` (les locations regex passent avant les préfixes simples) — sans précaution, l'auth aurait pu être contournée pour les fichiers `.php` de l'admin. Résolu avec `location ^~ /Calendar/ADMIN/` + un bloc `\.php$` imbriqué qui répète explicitement `auth_basic`, et **vérifié directement** plutôt que supposé correct (voir test plan).

## Mesures
Taille de l'image : 547MB -> 93MB (-83%)

## Test plan
Testé sur le VPS (build `--no-cache` + conteneur démarré réellement, `CALENDAR_ADMIN_USER`/`PASSWORD` factices) :
- [x] `.htpasswd` généré correctement au démarrage
- [x] `/` répond 200
- [x] `Calendar/data/` répond 403 (bloqué, comme avant)
- [x] `Calendar/ADMIN/index.php` SANS identifiants → 401
- [x] `Calendar/ADMIN/` (répertoire) SANS identifiants → 401
- [x] `Calendar/ADMIN/modules/gameList.php` SANS identifiants → 401 (le point sensible : confirme qu'aucun `.php` de l'admin n'échappe à l'auth)
- [x] `Calendar/ADMIN/index.php` avec MAUVAIS identifiants → 401
- [x] `Calendar/ADMIN/index.php` avec BONS identifiants → 200
- [x] `curl_init()` disponible dans le conteneur

Closes #73